### PR TITLE
Saves the username and password of the iTunes account into the keychain

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "KeychainAccess",
+        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+        "state": {
+          "branch": null,
+          "revision": "f77a025d2682b958722b28f69e84c0dc7318df7f",
+          "version": "3.1.2"
+        }
+      },
+      {
         "package": "LegibleError",
         "repositoryURL": "https://github.com/mxcl/LegibleError.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .target(
             name: "xcodes",
             dependencies: [
-                "Guaka", "XcodesKit"
+                "Guaka", "XcodesKit", "KeychainAccess"
             ]),
         .testTarget(
             name: "xcodesTests",
@@ -30,7 +30,7 @@ let package = Package(
         .target(
             name: "XcodesKit",
             dependencies: [
-                "AppleAPI", "Path", "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError", "KeychainAccess"
+                "AppleAPI", "Path", "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError"
             ]),
         .testTarget(
             name: "XcodesKitTests",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
         .package(url: "https://github.com/mxcl/PromiseKit.git", .upToNextMinor(from: "6.8.3")),
         .package(url: "https://github.com/PromiseKit/Foundation.git", .upToNextMinor(from: "3.3.1")),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", .upToNextMinor(from: "1.7.5")),
-        .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1"))
+        .package(url: "https://github.com/mxcl/LegibleError.git", .upToNextMinor(from: "1.0.1")),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMinor(from: "3.1.2"))
     ],
     targets: [
         .target(
@@ -29,7 +30,7 @@ let package = Package(
         .target(
             name: "XcodesKit",
             dependencies: [
-                "AppleAPI", "Path", "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError"
+                "AppleAPI", "Path", "Version", "PromiseKit", "PMKFoundation", "SwiftSoup", "LegibleError", "KeychainAccess"
             ]),
         .testTarget(
             name: "XcodesKitTests",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ error: terminated(72): xcrun --sdk macosx --find xctest output:
 
 ```
 
-If that occurs, it means you need to select a version of Xcode. You can do this with `xcode-select` or by choosing a Command Line Tools option in Xcode's preferences Locations tab. 
+If that occurs, it means you need to select a version of Xcode. You can do this with `xcode-select` or by choosing a Command Line Tools option in Xcode's preferences Locations tab.
 </details>
 
 ## Usage
@@ -39,6 +39,8 @@ If that occurs, it means you need to select a version of Xcode. You can do this 
 E.g. `xcodes install 10.1`
 
 You'll then be prompted to enter your Apple ID username and password. You can also provide these with the `XCODES_USERNAME` and `XCODES_PASSWORD` environment variables.
+
+After successful log in, xcodes will save your Apple ID password into the keychain for quick retrieval subsequent tries.
 
 ### Commands
 

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -27,7 +27,7 @@ func loginIfNeeded() -> Promise<Void> {
     .recover { error -> Promise<Void> in
         guard
             let username = findUsername() ?? readLine(prompt: "Apple ID: "),
-            let password = findPassword() ?? readSecureLine(prompt: "Apple ID Password: ")
+            let password = findPassword(withUserName: username) ?? readSecureLine(prompt: "Apple ID Password: ")
         else { throw Error.missingUsernameOrPassword }
 
         return login(username, password: password)
@@ -38,17 +38,14 @@ func findUsername() -> String? {
     if let username = env(xcodesUsername) {
         return username
     }
-    else if let username = try? keychain.getString(xcodesUsername){
-        return username
-    }
     return nil
 }
 
-func findPassword() -> String? {
+func findPassword(withUserName username: String) -> String? {
     if let password = env(xcodesPassword) {
         return password
     }
-    else if let password = try? keychain.getString(xcodesPassword){
+    else if let password = try? keychain.getString(username){
         return password
     }
     return nil
@@ -59,8 +56,7 @@ func login(_ username: String, password: String) -> Promise<Void> {
         manager.client.login(accountName: username, password: password)
     }
     .get { _ in
-        keychain[xcodesUsername] = username
-        keychain[xcodesPassword] = password
+        keychain[username] = password
     }
 }
 

--- a/Sources/xcodes/main.swift
+++ b/Sources/xcodes/main.swift
@@ -8,7 +8,7 @@ import Path
 import KeychainAccess
 
 let manager = XcodeManager()
-let keychain = Keychain(service: "com.interstateone.xcodes")
+let keychain = Keychain(service: "ca.brandonevans.xcodes")
 
 let xcodesUsername = "XCODES_USERNAME"
 let xcodesPassword = "XCODES_PASSWORD"
@@ -59,8 +59,8 @@ func login(_ username: String, password: String) -> Promise<Void> {
         manager.client.login(accountName: username, password: password)
     }
     .get { _ in
-        keychain["xcodesUsername"] = username
-        keychain["xcodesPassword"] = password
+        keychain[xcodesUsername] = username
+        keychain[xcodesPassword] = password
     }
 }
 


### PR DESCRIPTION
Fixes #11 

Using KeychainAccess as a dependency. This automatically saves the username and password into the keychain for use at a later time.

Currently checks for Environment variables first, then keychain, then prompts the user. There is an awkward prompt when saving, with the keychain name that was set. Perhaps this should be set to more descriptive, and less syntactically correct.

